### PR TITLE
Move travelingDefiers logic into gridAlign

### DIFF
--- a/main.js
+++ b/main.js
@@ -242,21 +242,17 @@ class Subble {
 		} else {
 			this.ancestor = this;
 		}
-		this.gridAlign([this]);
+		this.gridAlign();
 	}
-	decideTravelers(BOOL) {
-		Sbls.travelers = [];
-		const f = function(CHILD) {
-			if (CHILD.selected === BOOL) {
-				Sbls.travelers.push(CHILD);
-			} else {
-				Sbls.travelingDefiers.add(CHILD);
+	decideTravelers(SELECTED) {
+		Sbls.travelers.clear()
+		for (const node of this.subtree()) {
+			if (node.selected === SELECTED) {
+				Sbls.travelers.add(node);
 			}
 		}
-		f(this);
-		this.forOffspring(f);
 	}
-	gridAlign(TRAVELERS) {
+	gridAlign() {
 		let newPos;
 		if (this.parents.length > 0) {
 			const parentPos = this.parents[0].pos;
@@ -281,7 +277,19 @@ class Subble {
 			newPos = this.gridPos;
 		}
 		const correction = math.subtract(newPos, this.pos);
-		Sbls.moveTravelers(correction[0], correction[1], TRAVELERS);
+
+		const rootSelected = this.selected;
+		function *similarDescendants(PARENT) {
+			yield PARENT;
+			for (const child of PARENT.children) {
+				if (child.selected === rootSelected) {
+					yield *similarDescendants(child);
+				} else {
+					child.gridAlign();
+				}
+			}
+		}
+		Sbls.moveTravelers(correction[0], correction[1], similarDescendants(this));
 	}
 	adopt(CHILD) {
 		if (this.parents.indexOf(CHILD) === -1) {
@@ -317,9 +325,14 @@ class Subble {
 		this.forOffspring(f);
 	}
 	changeAncestor(ANCESTOR) {
-		this.ancestor = ANCESTOR;
-		for(const obj1 of this.children) {
-			obj1.changeAncestor(ANCESTOR);
+		for (const node of this.subtree()) {
+			node.ancestor = ANCESTOR;
+		}
+	}
+	*subtree() {
+		yield this;
+		for (const child of this.children) {
+			yield *child.subtree();
 		}
 	}
 	forOffspring(FUNCTION) { //Do for all children, grandchildren, a.s.f...
@@ -341,8 +354,7 @@ var Sbls = {
 	instances: [], 
 	instancesRendered: [], 
 	instancesSelected: [], 
-	travelers: [], 
-	travelingDefiers: new Set(), 
+	travelers: new Set(), 
 	mouseForSelection: true, 
 	generationGap: 1/2, //Size proportion from each subble to its child
 	parentMaxGap: 9999, //Max allowed distance to parents in local coordinates
@@ -446,26 +458,9 @@ var Sbls = {
 				const deltaY = -obj1.pos[1] +obj1.pickedUpPos[1];
 				this.moveTravelers(deltaX, deltaY, Sbls.travelers);
 			}
-			const oldest = Sbls.lowestSubble(Sbls.travelers);
-			oldest.gridAlign(Sbls.travelers);
-
-			if (Sbls.travelingDefiers.size > 0 && Sbls.travelers.length > 0) {
-				function *contiguousDescendants(PARENT, DEFIERS) {
-					yield PARENT;
-					for (const child of PARENT.children) {
-						if (Sbls.travelingDefiers.has(child) === DEFIERS) {
-							yield *contiguousDescendants(child, DEFIERS);
-						} else {
-							child.gridAlign(contiguousDescendants(child, !DEFIERS));
-						}
-					}
-				}
-				const oldestDefier = Sbls.lowestSubble(Sbls.travelingDefiers);
-				oldestDefier.gridAlign(contiguousDescendants(oldestDefier, true));
-			}
+			clickedObject.gridAlign();
 		}
-		Sbls.travelers = [];
-		Sbls.travelingDefiers = new Set();
+		Sbls.travelers.clear()
 	}, 
 	draw() {
 		stroke(255);


### PR DESCRIPTION
also, add a Sbls.subtree generator method, convert Sbls.travelers to a
Set, and remove travelingDefiers which is no longer needed.

Perhaps subtree is not the best name for this method since the hierarchy
is not in fact a tree, but rather a Directed Acyclic Graph, but I don't
know the corresponding term for DAGs. It's not "subgraph", that's
something else.